### PR TITLE
Rename `BUILD_DIR` to `PUBLISH_DIR`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const canonicalRoot = process.env.URL;
 
 module.exports = {
   onPostBuild: async ({
-    constants: { BUILD_DIR },
+    constants: { PUBLISH_DIR },
     inputs: {
       entryPoints,
       skipPatterns,
@@ -21,7 +21,7 @@ module.exports = {
     },
   }) => {
     /** @type {string} */
-    const root = BUILD_DIR;
+    const root = PUBLISH_DIR;
 
     /** @type {FilterFunction} */
     const skipFilter = (report) =>


### PR DESCRIPTION
The `BUILD_DIR` constant has been renamed to `PUBLISH_DIR`. This PR helps out with this :)