### PR TITLE
bump tap-spot to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@munter/tap-render": "^0.2.0",
     "globby": "^11.0.0",
     "hyperlink": "^4.5.0",
-    "tap-spot": "^1.1.1"
+    "tap-spot": "^1.1.2"
   },
   "devDependencies": {
     "@netlify/build": "11.14.0",


### PR DESCRIPTION
tap-spot 1.1.2 fixed warning from package.json (main field not pointing to index.js).
Having the last version here would remove warning when using netlify-plugin-checklinks